### PR TITLE
Fix determination current activity after minimizing using Home button

### DIFF
--- a/lib/adb.js
+++ b/lib/adb.js
@@ -1277,19 +1277,25 @@ ADB.prototype.androidCoverage = function (instrumentClass, waitPkg, waitActivity
 
 ADB.prototype.getFocusedPackageAndActivity = function (cb) {
   logger.debug("Getting focused package and activity");
-  var cmd = "dumpsys window windows"
-      , nullRe = new RegExp(/mFocusedApp=null/)
-      , searchRe = new RegExp(
+  var cmd = 'dumpsys window windows | grep -E "mCurrentFocus|mFocusedApp"';
+  var nullRe = new RegExp(/mFocusedApp=null/);
+  var searchFocusedAppRe = new RegExp(
           /mFocusedApp.+Record\{.*\s([^\s\/\}]+)\/([^\s\/\}]+)(\s[^\s\/\}]+)*\}/);
+  var searchCurrentFocusRe = new RegExp(
+          /mCurrentFocus.+\s([^\s\/\}]+)\/[^\s\/\}]+(\.[^\s\/\}]+)}/);
 
   this.shell(cmd, function (err, stdout) {
     if (err) return cb(err);
     var foundMatch = false;
     var foundNullMatch = false;
+
     _.each(stdout.split("\n"), function (line) {
-      var match = searchRe.exec(line);
-      if (match) {
-        foundMatch = match;
+      var matchCurrentFocus = searchCurrentFocusRe.exec(line);
+      var matchFocusedApp = searchFocusedAppRe.exec(line);
+      if (matchCurrentFocus) {
+        foundMatch = matchCurrentFocus;
+      } else if (matchFocusedApp && !foundMatch) {
+        foundMatch = matchFocusedApp;
       } else if (nullRe.test(line)) {
         foundNullMatch = true;
       }


### PR DESCRIPTION
Current pull request fix following problem:
after minimizing application using `Home` button, appuim determine current activity incorrect. It happens because appuim used `mFocusedApp` field for it, however it is not always correct. 
There are couple of issues on appium repo (eg.: [this one](https://github.com/appium/appium/issues/4489) or [this one](https://github.com/appium/appium/issues/5181)), which people complain about this problem in. But seems like it won't be fixed, because (as appium developers said) it is Android problem.
This modification make it possible to consider `mCurrentFocus` and `mFocusedApp` fields for getting current package and activity:
- will be used`mCurrentFocus` with highest priority
- in case `mCurrentFocus` is null or can't be parsed it will look at `mFocusedApp`
- in case `mFocusedApp` is null, the `null` will be returned
- in other cases will be return `null` and print error message

The behavior of two last steps didn't modified in current pull request.

Also I add `grep` for making `_.each` little bit faster and don't iterate unused lines
