### PR TITLE
MOBSEARCHANDROID-6165 Support getLogsIteratively

### DIFF
--- a/lib/adb.js
+++ b/lib/adb.js
@@ -1066,6 +1066,13 @@ ADB.prototype.getLogcatLogs = function () {
   return this.logcat.getLogs();
 };
 
+ADB.prototype.getLogcatLogsIteratively = function (messageLimit, textBodyLimit) {
+  if (this.logcat === null) {
+    throw new Error("Can't get logcat iterative logs since logcat hasn't started");
+  }
+  return this.logcat.getLogsIteratively(messageLimit, textBodyLimit);
+};
+
 ADB.prototype.getPIDsByName = function (name, cb) {
   logger.debug("Getting all processes with '" + name + "'");
   this.shell("ps '" + name + "'", function (err, stdout) {

--- a/lib/logcat.js
+++ b/lib/logcat.js
@@ -110,6 +110,31 @@ Logcat.prototype.getLogs = function () {
   return ret;
 };
 
+Logcat.prototype.getLogsIteratively = function (messageLimit, textBodyLimit) {
+  var current = this.logsSinceLastRequest;
+  var len = current.length;
+  if (messageLimit && len > messageLimit) {
+    len = messageLimit;
+  }
+  if (textBodyLimit && len > 0) {
+    var charSum = 0;
+    for (var pos = 0; pos < len; pos++) {
+      charSum += current[pos].message.length;
+      if (charSum > textBodyLimit) {
+        break;
+      }
+    }
+    if (pos == 0) {
+      pos = 1;
+    }
+    len = pos;
+  }
+  var ret = current.splice(0, len);
+  var rest = current.splice(len, current.length);
+  this.logsSinceLastRequest = rest;
+  return ret;
+};
+
 Logcat.prototype.getAllLogs = function () {
   return this.logs;
 };


### PR DESCRIPTION
Hi @d0lfin 
Would you care to take a look at this PR (#1 of 2), that deals with the problem of massive log bundle causing OOM in selenium.
The idea is that we should read logs in chunks.
Does it look reasonable?